### PR TITLE
Use CSE logger to log progress

### DIFF
--- a/src/run_common.cpp
+++ b/src/run_common.cpp
@@ -1,5 +1,7 @@
 #include "run_common.hpp"
 
+#include <cse/log/logger.hpp>
+
 #include <ios>
 #include <iostream>
 
@@ -72,13 +74,10 @@ void progress_logger::update(cse::time_point currentTime)
     const auto progress =
         100.0 * (currentDuration.count() / fullDuration_.count());
     while (nextPercentage_ <= progress) {
-        // NOTE: The use of std::clog here is a temporary solution while
-        // we wait for cse-core issue #110. We should use the same logging
-        // mechanism as cse-core, so all output can be filtered by the user.
-        std::clog
+        BOOST_LOG_SEV(cse::log::logger(), cse::log::info)
             << nextPercentage_ << "% complete, t="
             << std::fixed << cse::to_double_time_point(currentTime)
-            << std::defaultfloat << std::endl;
+            << std::defaultfloat;
         nextPercentage_ += percentIncrement_;
     }
 }


### PR DESCRIPTION
This finally closes issue #6.

Here is what the output (or lack thereof) looks like now:
```
> cse run-single cse-core\test\data\ssp\demo\KnuckleBoomCrane.fmu
> cse run-single cse-core\test\data\ssp\demo\KnuckleBoomCrane.fmu --log-level=info
info: [FMI Library: FMILIB] Loading 'win64' binary with 'default' platform types
info: 10% complete, t=0.100000
info: 20% complete, t=0.200000
info: 30% complete, t=0.300000
info: 40% complete, t=0.400000
info: 50% complete, t=0.500000
info: 60% complete, t=0.600000
info: 70% complete, t=0.700000
info: 80% complete, t=0.800000
info: 90% complete, t=0.900000
info: 100% complete, t=1.000000
```
Note, this is not a fix for issue #12. I'll add a new switch for producing machine-readable output. This is for the user.