### PR TITLE
Add machine-readable progress logging

### DIFF
--- a/src/run.cpp
+++ b/src/run.cpp
@@ -42,8 +42,9 @@ public:
     progress_monitor(
         cse::time_point startTime,
         cse::duration duration,
-        int percentIncrement = 10)
-        : logger_(startTime, duration, percentIncrement)
+        int percentIncrement,
+        std::optional<int> mrProgressResolution)
+        : logger_(startTime, duration, percentIncrement, mrProgressResolution)
     {}
 
 private:
@@ -95,7 +96,9 @@ int run_subcommand::run(const boost::program_options::variables_map& args) const
     execution.add_observer(
         std::make_shared<progress_monitor>(
             runOptions.begin_time,
-            runOptions.end_time - runOptions.begin_time));
+            runOptions.end_time - runOptions.begin_time,
+            10,
+            runOptions.mr_progress_resolution));
 
     execution.simulate_until(runOptions.end_time).get();
     return 0;

--- a/src/run_common.cpp
+++ b/src/run_common.cpp
@@ -22,6 +22,15 @@ void setup_common_run_options(
             boost::program_options::value<double>(),
             "The logical end time of the simulation.  "
             "Excludes -d/--duration.")
+        ("mr-progress",
+            boost::program_options::value<int>()->value_name("resolution")->implicit_value(10),
+            "Enables printing of machine-readable progress indicator lines on "
+            "the form '@progress n t d'.  "
+            "Here, n indicates the progress in 1/N-ths of the total time, "
+            "where N is the resolution given as an argument to this option.  "
+            "t is the current logical time and d is the amount of logical "
+            "time that has passed since the start of the simulation.  "
+            "t and d are floating-point numbers while n is an integer.")
         ("real-time",
             boost::program_options::value<double>()->value_name("target_rtf")->implicit_value(1),
             "Enables real-time-synchronised simulations.  A target RTF may "
@@ -47,6 +56,9 @@ common_run_option_values get_common_run_options(
             values.begin_time + cse::to_duration(args["duration"].as<double>());
     }
 
+    if (args.count("mr-progress")) {
+        values.mr_progress_resolution = args["mr-progress"].as<int>();
+    }
     if (args.count("real-time")) {
         values.rtf_target = args["real-time"].as<double>();
     }
@@ -54,30 +66,45 @@ common_run_option_values get_common_run_options(
 }
 
 
-using double_duration = std::chrono::duration<double>;
-
-
 progress_logger::progress_logger(
     cse::time_point startTime,
     cse::duration duration,
-    int percentIncrement)
+    int percentIncrement,
+    std::optional<int> mrProgressResolution)
     : startTime_(startTime)
-    , fullDuration_(std::chrono::duration_cast<double_duration>(duration))
+    , fullDuration_(cse::to_double_duration(duration, startTime))
     , percentIncrement_(percentIncrement)
+    , mrProgressResolution_(mrProgressResolution)
+    , nextPercentage_(percentIncrement)
 {}
 
 
 void progress_logger::update(cse::time_point currentTime)
 {
     const auto currentDuration =
-        std::chrono::duration_cast<double_duration>(currentTime - startTime_);
-    const auto progress =
-        100.0 * (currentDuration.count() / fullDuration_.count());
-    while (nextPercentage_ <= progress) {
+        cse::to_double_duration(currentTime - startTime_, startTime_);
+    const auto progress = currentDuration / fullDuration_;
+
+    const auto percentProgress = 100.0 * progress;
+    while (nextPercentage_ <= percentProgress) {
         BOOST_LOG_SEV(cse::log::logger(), cse::log::info)
             << nextPercentage_ << "% complete, t="
             << std::fixed << cse::to_double_time_point(currentTime)
             << std::defaultfloat;
         nextPercentage_ += percentIncrement_;
+    }
+
+    if (mrProgressResolution_) {
+        const auto mrProgress = *mrProgressResolution_ * progress;
+        while (nextMRProgress_ <= mrProgress) {
+            std::cout
+                << "@progress "
+                << nextMRProgress_ << ' '
+                << std::fixed
+                << cse::to_double_time_point(currentTime) << ' '
+                << currentDuration
+                << std::defaultfloat << std::endl;
+            ++nextMRProgress_;
+        }
     }
 }

--- a/src/run_common.hpp
+++ b/src/run_common.hpp
@@ -20,6 +20,7 @@ struct common_run_option_values
     cse::time_point begin_time;
     cse::time_point end_time;
     std::optional<double> rtf_target;
+    std::optional<int> mr_progress_resolution;
 };
 
 
@@ -35,15 +36,18 @@ public:
     progress_logger(
         cse::time_point startTime,
         cse::duration duration,
-        int percentIncrement);
+        int percentIncrement,
+        std::optional<int> mrProgressResolution);
 
     void update(cse::time_point currentTime);
 
 private:
     const cse::time_point startTime_;
-    const std::chrono::duration<double> fullDuration_;
+    const double fullDuration_;
     const int percentIncrement_;
-    int nextPercentage_ = 10;
+    const std::optional<int> mrProgressResolution_;
+    int nextPercentage_;
+    int nextMRProgress_ = 1;
 };
 
 

--- a/src/run_single.cpp
+++ b/src/run_single.cpp
@@ -237,7 +237,8 @@ int run_single_subcommand::run(const boost::program_options::variables_map& args
     progress_logger progress(
         runOptions.begin_time,
         runOptions.end_time - runOptions.begin_time,
-        10);
+        10,
+        runOptions.mr_progress_resolution);
 
     cse::real_time_timer timer;
     if (runOptions.rtf_target) {


### PR DESCRIPTION
This resolves issue #12. If the `--mr-progress` option is given to either `cse run` or `cse run-single`, it prints lines on the form
```
@progress n t d
```
to standard output, where `n` is the progress in increments of a given resolution (e.g. `--mr-progress=100`, default is 10 if not specified), `t` is the current simulation time, and `d` is the simulation time that has passed since the start of the simulation. A new line is printed each time `n` increases by 1.

I did not include the resolution, the total time or total duration in the output, as the calling program/user has this information already.

I envision this as the first of several `--mr-xxx` options to come, where `mr` stands for "machine readable", and lines are printed as `@xxx <info>`.

~This PR is targeted on #13 to avoid unnecessary conflict and noise. I'll retarget on master once #13 is merged.~