### PR TITLE
run-single: Validate step size

### DIFF
--- a/src/run_single.cpp
+++ b/src/run_single.cpp
@@ -233,6 +233,9 @@ int run_single_subcommand::run(const boost::program_options::variables_map& args
 {
     const auto runOptions = get_common_run_options(args);
     const auto stepSize = cse::to_duration(args["step-size"].as<double>());
+    if (stepSize <= cse::duration(0)) {
+        throw boost::program_options::error("Invalid step size (must be >0)");
+    }
 
     progress_logger progress(
         runOptions.begin_time,
@@ -291,7 +294,7 @@ int run_single_subcommand::run(const boost::program_options::variables_map& args
                 "Simulator was unable to complete time step at t=" +
                 std::to_string(cse::to_double_time_point(t)));
         }
-        t += stepSize;
+        t += dt;
         output.update(t);
         timer.sleep(t);
         progress.update(t);


### PR DESCRIPTION
This adds a check that the step size is positive, and I've made a small fix to the simulation algorithm that makes it handle the last time step properly so that t never exceeds the end time, even if the step size is greater than the total simulation time.

This closes issue #14.