### PR TITLE
Copy .exe and .dlls to bin folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,3 +59,9 @@ target_link_libraries(cse
     PRIVATE
         csecore::csecorecpp
         Boost::program_options)
+
+set_target_properties(cse
+    PROPERTIES
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,3 +3,6 @@ cse-core/0.4.0@osp/master
 
 [generators]
 cmake
+
+[imports]
+bin, *.dll -> ./bin # Copies all dll files from packages bin folder to my local "bin" folder


### PR DESCRIPTION
I kinda need this in order to run the .exe (without copying it anywhere after compilation). 
Not sure how you go about this? 