### PR TITLE
Fix 'inspect' and 'run-single' URI/path handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ add_executable(cse
     "src/run_common.cpp"
     "src/run_single.hpp"
     "src/run_single.cpp"
+    "src/tools.hpp"
+    "src/tools.cpp"
     "src/version_option.hpp"
     "src/version_option.cpp"
 )

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,3 +4,4 @@ bzip2/1.0.8@conan/stable
 
 [generators]
 cmake
+virtualrunenv

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -1,12 +1,11 @@
 #include "inspect.hpp"
 
+#include "tools.hpp"
+
 #include <boost/filesystem.hpp>
 #include <cse/orchestration.hpp>
 #include <cse/uri.hpp>
 
-#ifdef _WIN32
-#    include <cctype>
-#endif
 #include <iomanip>
 #include <iostream>
 
@@ -61,16 +60,6 @@ void print_variable_descriptions(const cse::model_description& md)
     }
 }
 
-#ifdef _WIN32
-bool looks_like_path(std::string_view str)
-{
-    return str.size() > 2 &&
-        std::isalpha(static_cast<unsigned char>(str[0])) &&
-        str[1] == ':' &&
-        (str[2] == '\\' || str[2] == '/');
-}
-#endif
-
 } // namespace
 
 
@@ -79,18 +68,7 @@ int inspect_subcommand::run(const boost::program_options::variables_map& args) c
     auto currentPath = boost::filesystem::current_path();
     currentPath += boost::filesystem::path::preferred_separator;
     const auto baseUri = cse::path_to_file_uri(currentPath);
-
-    // On Windows, we treat anything that starts with "X:\" as a path,
-    // even though it could in principle be a URI with scheme "X".
-    const auto uriOrPath = args["uri_or_path"].as<std::string>();
-#ifdef _WIN32
-    const auto uriReference = looks_like_path(uriOrPath)
-        ? cse::path_to_file_uri(uriOrPath)
-        : cse::uri(uriOrPath);
-#else
-    const auto uriReference = cse::uri(uriOrPath);
-#endif
-
+    const auto uriReference = to_uri(args["uri_or_path"].as<std::string>());
     const auto uriResolver = cse::default_model_uri_resolver();
     const auto model = uriResolver->lookup_model(baseUri, uriReference);
     print_model_description(*model->description());

--- a/src/run_single.cpp
+++ b/src/run_single.cpp
@@ -4,6 +4,7 @@
 #include "run_single.hpp"
 
 #include "run_common.hpp"
+#include "tools.hpp"
 
 #include <boost/container/vector.hpp>
 #include <boost/filesystem.hpp>
@@ -251,10 +252,9 @@ int run_single_subcommand::run(const boost::program_options::variables_map& args
     auto currentPath = boost::filesystem::current_path();
     currentPath += boost::filesystem::path::preferred_separator;
     const auto baseUri = cse::path_to_file_uri(currentPath);
+    const auto uriReference = to_uri(args["uri_or_path"].as<std::string>());
     const auto uriResolver = cse::default_model_uri_resolver();
-    const auto model = uriResolver->lookup_model(
-        baseUri,
-        args["uri_or_path"].as<std::string>());
+    const auto model = uriResolver->lookup_model(baseUri, uriReference);
 
     std::optional<variable_values> initialValues;
     if (args.count("initial_value") > 0) {

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1,0 +1,26 @@
+#include "tools.hpp"
+
+#include <boost/filesystem.hpp>
+
+#ifdef _WIN32
+#    include <cctype>
+#endif
+
+
+cse::uri to_uri(std::string_view str)
+{
+    auto uri = cse::uri(str);
+#ifdef _WIN32
+    // On Windows, we treate anything that starts with a single letter followed
+    // by a colon as a path, even though it could also be interpreted as an URI
+    // with a single-character scheme.
+    const auto schemeLooksLikeDriveLetter =
+        uri.scheme() &&
+        uri.scheme()->size() == 1 &&
+        std::isalpha(static_cast<unsigned char>(uri.scheme()->front()));
+    if (schemeLooksLikeDriveLetter || !uri.scheme()) {
+        uri = cse::path_to_file_uri(boost::filesystem::path(str.begin(), str.end()));
+    }
+#endif
+    return uri;
+}

--- a/src/tools.hpp
+++ b/src/tools.hpp
@@ -1,0 +1,16 @@
+#ifndef CSECLI_TOOLS_HPP
+#define CSECLI_TOOLS_HPP
+
+#include <cse/uri.hpp>
+
+#include <string_view>
+
+
+/**
+ *  Converts the given string, which may contain a URI or a filesystem path,
+ *  to a `cse::uri` object.
+ */
+cse::uri to_uri(std::string_view str);
+
+
+#endif


### PR DESCRIPTION
Fixes #25: Root-relative FMU path interpreted incorrectly on Windows.
Fixes #26: run-single: Absolute Windows path interpreted as URI.