### PR TITLE
Update cse-core version to v0.5.1

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,5 @@
 [requires]
-cse-core/0.5.0@osp/v0.5.0
-bzip2/1.0.8@conan/stable
+cse-core/0.5.1@osp/v0.5.1
 
 [generators]
 cmake


### PR DESCRIPTION
This updates `cse-core` to the latest release. I also removed the `bzip2/1.0.8` version override as this is redundant.