### PR TITLE
Include license files in release bundles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,3 +82,4 @@ target_link_libraries(cosim
 
 install(TARGETS cosim RUNTIME DESTINATION bin)
 include(InstallRequiredSystemLibraries)
+install(FILES "LICENSE" "README.md" DESTINATION "doc")

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -33,3 +33,12 @@ lib, libboost_regex.so.*           -> ./dist/lib
 lib, libboost_system.so.*          -> ./dist/lib
 lib, libboost_thread.so.*          -> ./dist/lib
 lib, libcosim.so                   -> ./dist/lib
+
+., license*     -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., */license*   -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., copying*     -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., */copying*   -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., notice*      -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., */notice*    -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., authors*     -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., */authors*   -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False


### PR DESCRIPTION
This includes both our own `LICENSE` file (and our `README.md`, incidentally) together with the license files of all dependencies. These include files like `LICENSE*`, `AUTHORS*`, `COPYING*` and `licenses/*` (case insensitive), grabbed from the Conan packages.  The resulting installation tree looks like this:

    bin/
    doc/
      LICENSE
      README.md
      <dependency1>/
        LICENSE
        ...
      <dependency2>/
        LICENSE
        ...
      ...

This fixes #70.