### PR TITLE
Include more dependencies of libcosim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,14 @@ target_link_libraries(cosim
         libcosim::cosim
         Boost::program_options)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # This makes the linker set RPATH rather than RUNPATH for the resulting
+    # binary, so that the indirect dependencies between dynamic libraries in
+    # our installation directory resolve correctly. (RPATH is transitive,
+    # RUNPATH is not.)
+    target_link_options(cosim PRIVATE "LINKER:--disable-new-dtags")
+endif()
+
 # ==============================================================================
 # Installation
 # ==============================================================================

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-libcosim/0.8.0@osp/feature_595-link-dependencies-dynamically
+libcosim/0.8.0@osp/master
 
 [generators]
 cmake

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-libcosim/0.8.0@feature_595-link-dependencies-dynamically
+libcosim/0.8.0@osp/feature_595-link-dependencies-dynamically
 
 [generators]
 cmake

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -19,6 +19,10 @@ lib, boost_regex*.dll              -> ./dist/bin
 lib, boost_system*.dll             -> ./dist/bin
 lib, boost_thread*.dll             -> ./dist/bin
 bin, cosim.dll                     -> ./dist/bin
+bin, fmilib_shared.dll             -> ./dist/bin
+bin, xerces-c*.dll                 -> ./dist/lib
+bin, yaml-cpp.dll                  -> ./dist/lib
+bin, libzip.dll                    -> ./dist/lib
 
 lib, libboost_atomic.so.*          -> ./dist/lib
 lib, libboost_chrono.so.*          -> ./dist/lib
@@ -33,3 +37,7 @@ lib, libboost_regex.so.*           -> ./dist/lib
 lib, libboost_system.so.*          -> ./dist/lib
 lib, libboost_thread.so.*          -> ./dist/lib
 lib, libcosim.so                   -> ./dist/lib
+lib, libfmilib_shared.so           -> ./dist/lib
+lib, libxerces-c*.so               -> ./dist/lib
+lib, libyaml-cpp.so.*              -> ./dist/lib
+lib, libzip.so.*                   -> ./dist/lib

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -20,9 +20,9 @@ lib, boost_system*.dll             -> ./dist/bin
 lib, boost_thread*.dll             -> ./dist/bin
 bin, cosim.dll                     -> ./dist/bin
 bin, fmilib_shared.dll             -> ./dist/bin
-bin, xerces-c*.dll                 -> ./dist/lib
-bin, yaml-cpp.dll                  -> ./dist/lib
-bin, libzip.dll                    -> ./dist/lib
+bin, xerces-c*.dll                 -> ./dist/bin
+bin, yaml-cpp.dll                  -> ./dist/bin
+bin, zip.dll                       -> ./dist/bin
 
 lib, libboost_atomic.so.*          -> ./dist/lib
 lib, libboost_chrono.so.*          -> ./dist/lib

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-libcosim/0.8.0@osp/master
+libcosim/0.8.0@feature_595-link-dependencies-dynamically
 
 [generators]
 cmake


### PR DESCRIPTION
This change accompanies open-simulation-platform/libcosim#596, and adds the now-dynamically-linked dependencies in the `dist/lib` folder.