### PR TITLE
(Trivial) Fix name of build steps in GH Actions workflow

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -38,7 +38,7 @@ jobs:
           sudo pip3 install conan
       - name: Configure Conan
         run: conan remote add osp https://osp-conan.azurewebsites.net/artifactory/api/conan/public --force
-      - name: Conan create
+      - name: Build
         run: |
           mkdir build
           cd build
@@ -77,7 +77,7 @@ jobs:
           pip3 install conan
       - name: Configure Conan
         run: conan remote add osp https://osp-conan.azurewebsites.net/artifactory/api/conan/public --force
-      - name: Conan create
+      - name: Build
         shell: bash
         run: |
           mkdir build


### PR DESCRIPTION
Since there's not even a `conan create` command in there...