### PR TITLE
Make cache directory configurable

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -31,6 +31,10 @@ const char* getenv(const char* variableName)
 // Obtain the (platform-specific) application cache path for the current user.
 std::optional<boost::filesystem::path> user_cache_directory_path()
 {
+    if (const auto cachePath = getenv("COSIM_CACHE_PATH")) {
+        return boost::filesystem::path(cachePath);
+    }
+
 #if defined(_WIN32)
     if (const auto localAppData = getenv("LocalAppData")) {
         return boost::filesystem::path(localAppData);

--- a/src/clean_cache.hpp
+++ b/src/clean_cache.hpp
@@ -38,7 +38,12 @@ public:
                "\n"
                "This command allows for safe removal of files from the cache.  "
                "It will remove all files that are not currently in use by another "
-               "cosim process.";
+               "cosim process.\n"
+               "\n"
+               "The location of the cache can be set using the environment "
+               "variable COSIM_CACHE_PATH.  "
+               "If this is not defined, the (platform-specific) default "
+               "application cache path for the current user will be used instead.";
     }
 
     void setup_options(


### PR DESCRIPTION
This introduces a new environment variable COSIM_CACHE_PATH that lets users choose a location. Documenting it in the help text for the `clean-cache` subcommand is perhaps not ideal, but I couldn't find a more appropriate place for it.

If we accrue more of these configurable features, we may later consider introducing a `~/.cosimconfig` file to let users configure them more permanently.

Fixes #75.