### PR TITLE
Use new channel name for libcosim

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-libcosim/0.8.0@osp/master
+libcosim/0.8.0@osp/testing
 
 [generators]
 cmake


### PR DESCRIPTION
Follows from open-simulation-platform/libcosim#600.