### PR TITLE
Use updated real-time API

### DIFF
--- a/src/run.cpp
+++ b/src/run.cpp
@@ -200,8 +200,9 @@ int run_subcommand::run(const boost::program_options::variables_map& args) const
         *uriResolver,
         runOptions.begin_time);
     if (runOptions.rtf_target) {
-        execution.set_real_time_factor_target(*runOptions.rtf_target);
-        execution.enable_real_time_simulation();
+        auto rtConfig = execution.get_real_time_config();
+        rtConfig->real_time_factor_target.store(*runOptions.rtf_target);
+        rtConfig->real_time_simulation.store(true);
     }
 
     auto outputObserver = make_file_observer(

--- a/src/run_single.cpp
+++ b/src/run_single.cpp
@@ -252,8 +252,9 @@ int run_single_subcommand::run(const boost::program_options::variables_map& args
 
     cosim::real_time_timer timer;
     if (runOptions.rtf_target) {
-        timer.set_real_time_factor_target(*runOptions.rtf_target);
-        timer.enable_real_time_simulation();
+        auto rtConfig = timer.get_real_time_config();
+        rtConfig->real_time_factor_target.store(*runOptions.rtf_target);
+        rtConfig->real_time_simulation.store(true);
     }
 
     auto currentPath = boost::filesystem::current_path();


### PR DESCRIPTION
This PR updates the usage of libcosim's timer API, which changed following merge of [libcosim PR #605](https://github.com/open-simulation-platform/libcosim/pull/605). 