### PR TITLE
Rename option proxyfmu and build with Docker

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        compiler_version: [7, 8, 9]
+        compiler_version: [8, 9]
         compiler_libcxx: [libstdc++11]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -22,7 +22,6 @@ jobs:
           mkdir /tmp/osp-builder-docker
           cat <<'EOF' >/tmp/osp-builder-docker/Dockerfile
           FROM conanio/gcc${{ matrix.compiler_version }}
-          FROM conanio/gcc${{ matrix.compiler_version }}
           ENV CONAN_LOGIN_USERNAME_OSP=${{ secrets.osp_artifactory_usr }}
           ENV CONAN_PASSWORD_OSP=${{ secrets.osp_artifactory_pwd }}
           ENV CONAN_REVISIONS_ENABLED=1
@@ -37,10 +36,11 @@ jobs:
           cat <<'EOF' >/tmp/osp-builder-docker/entrypoint.sh
           #!/bin/bash -v
           set -eu
+          cd /mnt/source/build
           conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
-          conan install .. -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} ../
+          conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} ..
           for f in dist/lib/*; do patchelf --set-rpath \$ORIGIN $f; done
-          cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ../
+          cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
           cmake --build .
           cmake --build . --target install
           EOF
@@ -50,7 +50,7 @@ jobs:
           docker build -t osp-builder /tmp/osp-builder-docker/
       - name: Build cosim
         run: |
-          docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source/build osp-builder
+          docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source osp-builder
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -37,7 +37,6 @@ jobs:
           cat <<'EOF' >/tmp/osp-builder-docker/entrypoint.sh
           #!/bin/bash -v
           set -eu
-          cd /mnt/source/build
           conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
           conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} ../
           for f in dist/lib/*; do patchelf --set-rpath \$ORIGIN $f; done
@@ -51,7 +50,7 @@ jobs:
           docker build -t osp-builder /tmp/osp-builder-docker/
       - name: Build cosim
         run: |
-          docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source osp-builder
+          docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source/build osp-builder
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -33,13 +33,12 @@ jobs:
           EOF
       - name: Generate entrypoint.sh
         run: |
+          mkdir build
           cat <<'EOF' >/tmp/osp-builder-docker/entrypoint.sh
           #!/bin/bash -v
           set -eu
-          cd /mnt/source
+          cd /mnt/source/build
           conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
-          mkdir build
-          cd build
           conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} ../
           for f in dist/lib/*; do patchelf --set-rpath \$ORIGIN $f; done
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ../

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -32,12 +32,12 @@ jobs:
           EOF
       - name: Generate entrypoint.sh
         run: |
+          mkdir build
+          chmod 777 build
           cat <<'EOF' >/tmp/osp-builder-docker/entrypoint.sh
           #!/bin/bash -v
           set -eu
-          cd /mnt/source
-          mkdir build
-          cd build
+          cd /mnt/source/build
           conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
           conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} ..
           for f in dist/lib/*; do patchelf --set-rpath \$ORIGIN $f; done

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -23,12 +23,12 @@ jobs:
         build_type: [Debug, Release]
         compiler_version: [7, 8, 9]
         compiler_libcxx: [libstdc++11]
-        option_fmuproxy: ['fmuproxy=True', 'fmuproxy=False']
+        option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 
         exclude:
           - os: ubuntu-18.04
             build_type: Debug
-            option_fmuproxy: 'fmuproxy=True'
+            option_proxyfmu: 'proxyfmu=True'
 
     steps:
       - uses: actions/checkout@v2
@@ -43,7 +43,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_fmuproxy }} ../
+          conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} ../
           for f in dist/lib/*; do patchelf --set-rpath \$ORIGIN $f; done
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ../
           cmake --build .
@@ -51,7 +51,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: cosim-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.compiler_version }}-${{ matrix.option_fmuproxy }}
+          name: cosim-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.compiler_version }}-${{ matrix.option_proxyfmu }}
           path: build/dist
 
   conan-on-windows:
@@ -63,12 +63,12 @@ jobs:
         os: [windows-2016]
         build_type: [Debug, Release]
         compiler_version: [15]
-        option_fmuproxy: ['fmuproxy=True', 'fmuproxy=False']
+        option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 
         exclude:
           - os: windows-2016
             build_type: Debug
-            option_fmuproxy: 'fmuproxy=True'
+            option_proxyfmu: 'proxyfmu=True'
 
     steps:
       - uses: actions/checkout@v2
@@ -83,12 +83,12 @@ jobs:
         run: |
           mkdir build
           cd build
-          conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -o libcosim:${{ matrix.option_fmuproxy }} ../
+          conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -o libcosim:${{ matrix.option_proxyfmu }} ../
           cmake -A x64 ../
           cmake --build . --config ${{ matrix.build_type }}
           cmake --build . --config ${{ matrix.build_type }} --target install
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: cosim-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.option_fmuproxy }}
+          name: cosim-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.option_proxyfmu }}
           path: build/dist

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -3,44 +3,41 @@ name: cosim CI Conan
 # This workflow is triggered on pushes to the repository.
 on: [push, workflow_dispatch]
 
-env:
-  CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}
-  CONAN_PASSWORD_OSP: ${{ secrets.osp_artifactory_pwd }}
-  CONAN_REVISIONS_ENABLED: 1
-  CONAN_NON_INTERACTIVE: True
-
 jobs:
   conan-on-linux:
     name: Conan
-    runs-on: ${{ matrix.os }}
-    env:
-      CC: gcc-${{ matrix.compiler_version }}
-      CXX: g++-${{ matrix.compiler_version }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
         build_type: [Debug, Release]
         compiler_version: [7, 8, 9]
         compiler_libcxx: [libstdc++11]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 
-        exclude:
-          - os: ubuntu-18.04
-            build_type: Debug
-            option_proxyfmu: 'proxyfmu=True'
-
     steps:
       - uses: actions/checkout@v2
-      - name: Install prerequisites
+      - name: Generate Dockerfile
         run: |
-          sudo apt-get install -y --no-install-recommends g++-8
-          sudo pip3 install --upgrade setuptools pip
-          sudo pip3 install conan
-      - name: Configure Conan
-        run: conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
-      - name: Build
+          mkdir /tmp/osp-builder-docker
+          cat <<'EOF' >/tmp/osp-builder-docker/Dockerfile
+          FROM conanio/gcc${{ matrix.compiler_version }}
+          FROM conanio/gcc${{ matrix.compiler_version }}
+          ENV CONAN_LOGIN_USERNAME_OSP=${{ secrets.osp_artifactory_usr }}
+          ENV CONAN_PASSWORD_OSP=${{ secrets.osp_artifactory_pwd }}
+          ENV CONAN_REVISIONS_ENABLED=1
+          ENV CONAN_NON_INTERACTIVE=1
+          ENV CONAN_USE_ALWAYS_SHORT_PATHS=1
+          COPY entrypoint.sh /
+          ENTRYPOINT /entrypoint.sh
+          EOF
+      - name: Generate entrypoint.sh
         run: |
+          cat <<'EOF' >/tmp/osp-builder-docker/entrypoint.sh
+          #!/bin/bash -v
+          set -eu
+          cd /mnt/source
+          conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
           mkdir build
           cd build
           conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} ../
@@ -48,6 +45,8 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ../
           cmake --build .
           cmake --build . --target install
+          EOF
+          chmod 0755 /tmp/osp-builder-docker/entrypoint.sh
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
@@ -57,6 +56,12 @@ jobs:
   conan-on-windows:
     name: Conan
     runs-on: ${{ matrix.os }}
+    env:
+      CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}
+      CONAN_PASSWORD_OSP: ${{ secrets.osp_artifactory_pwd }}
+      CONAN_REVISIONS_ENABLED: 1
+      CONAN_NON_INTERACTIVE: 1
+      CONAN_USE_ALWAYS_SHORT_PATHS: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -38,7 +38,7 @@ jobs:
           #!/bin/bash -v
           set -eu
           conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
-          conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} ../
+          conan install .. -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} ../
           for f in dist/lib/*; do patchelf --set-rpath \$ORIGIN $f; done
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ../
           cmake --build .

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -32,11 +32,12 @@ jobs:
           EOF
       - name: Generate entrypoint.sh
         run: |
-          mkdir build
           cat <<'EOF' >/tmp/osp-builder-docker/entrypoint.sh
           #!/bin/bash -v
           set -eu
-          cd /mnt/source/build
+          cd /mnt/source
+          mkdir build
+          cd build
           conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
           conan install -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} ..
           for f in dist/lib/*; do patchelf --set-rpath \$ORIGIN $f; done

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -22,6 +22,7 @@ jobs:
           mkdir /tmp/osp-builder-docker
           cat <<'EOF' >/tmp/osp-builder-docker/Dockerfile
           FROM conanio/gcc${{ matrix.compiler_version }}
+          USER root
           RUN apt-get update && apt-get install -y --force-yes patchelf
           ENV CONAN_LOGIN_USERNAME_OSP=${{ secrets.osp_artifactory_usr }}
           ENV CONAN_PASSWORD_OSP=${{ secrets.osp_artifactory_pwd }}

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -45,7 +45,7 @@ jobs:
           cmake --build .
           cmake --build . --target install
           EOF
-          chmod 0755 /tmp/osp-builder-docker/entrypoint.sh
+          chmod 0777 /tmp/osp-builder-docker/entrypoint.sh
       - name: Build Docker image
         run: |
           docker build -t osp-builder /tmp/osp-builder-docker/

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -22,6 +22,7 @@ jobs:
           mkdir /tmp/osp-builder-docker
           cat <<'EOF' >/tmp/osp-builder-docker/Dockerfile
           FROM conanio/gcc${{ matrix.compiler_version }}
+          RUN apt-get update && apt-get install -y --force-yes patchelf
           ENV CONAN_LOGIN_USERNAME_OSP=${{ secrets.osp_artifactory_usr }}
           ENV CONAN_PASSWORD_OSP=${{ secrets.osp_artifactory_pwd }}
           ENV CONAN_REVISIONS_ENABLED=1

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -47,6 +47,12 @@ jobs:
           cmake --build . --target install
           EOF
           chmod 0755 /tmp/osp-builder-docker/entrypoint.sh
+      - name: Build Docker image
+        run: |
+          docker build -t osp-builder /tmp/osp-builder-docker/
+      - name: Build cosim
+        run: |
+          docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source:ro osp-builder
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -45,13 +45,13 @@ jobs:
           cmake --build .
           cmake --build . --target install
           EOF
-          chmod 0777 /tmp/osp-builder-docker/entrypoint.sh
+          chmod 0755 /tmp/osp-builder-docker/entrypoint.sh
       - name: Build Docker image
         run: |
           docker build -t osp-builder /tmp/osp-builder-docker/
       - name: Build cosim
         run: |
-          docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source:ro osp-builder
+          docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source osp-builder
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.9)
 project("cosim" VERSION "0.5.0")
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/dist")
 
+# To enable verbose when needed
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
 # ==============================================================================
 # Global internal configuration
 # ==============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project("cosim" VERSION "0.5.0")
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/dist")
 
 # To enable verbose when needed
-set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 # ==============================================================================
 # Global internal configuration

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -6,23 +6,24 @@ cmake
 virtualrunenv
 
 [imports]
-lib, boost_atomic*.dll             -> ./dist/bin
-lib, boost_chrono*.dll             -> ./dist/bin
-lib, boost_context*.dll            -> ./dist/bin
-lib, boost_date_time*.dll          -> ./dist/bin
-lib, boost_fiber*.dll              -> ./dist/bin
-lib, boost_filesystem*.dll         -> ./dist/bin
-lib, boost_log*.dll                -> ./dist/bin
-lib, boost_log_setup*.dll          -> ./dist/bin
-lib, boost_program_options*.dll    -> ./dist/bin
-lib, boost_regex*.dll              -> ./dist/bin
-lib, boost_system*.dll             -> ./dist/bin
-lib, boost_thread*.dll             -> ./dist/bin
+bin, boost_atomic*.dll             -> ./dist/bin
+bin, boost_chrono*.dll             -> ./dist/bin
+bin, boost_context*.dll            -> ./dist/bin
+bin, boost_date_time*.dll          -> ./dist/bin
+bin, boost_fiber*.dll              -> ./dist/bin
+bin, boost_filesystem*.dll         -> ./dist/bin
+bin, boost_log*.dll                -> ./dist/bin
+bin, boost_log_setup*.dll          -> ./dist/bin
+bin, boost_program_options*.dll    -> ./dist/bin
+bin, boost_regex*.dll              -> ./dist/bin
+bin, boost_system*.dll             -> ./dist/bin
+bin, boost_thread*.dll             -> ./dist/bin
 bin, cosim.dll                     -> ./dist/bin
 bin, fmilib_shared.dll             -> ./dist/bin
 bin, xerces-c*.dll                 -> ./dist/bin
 bin, yaml-cpp.dll                  -> ./dist/bin
 bin, zip.dll                       -> ./dist/bin
+bin, proxyfmu*                     -> ./dist/bin
 
 lib, libboost_atomic.so.*          -> ./dist/lib
 lib, libboost_chrono.so.*          -> ./dist/lib


### PR DESCRIPTION
libcosim option fmuproxy is renamed to proxyfmu

Getting an error when linking in the `gcc9`-`proxyfmu=True`-[build](https://github.com/open-simulation-platform/cosim-cli/runs/3381610411?check_suite_focus=true) that I appreciate help on solving:
```
... /0.8.0/osp/testing/package/3123ab7ca3fc5a20c4e01288f8e98c00a155d3bd/lib/libcosim.so: undefined reference to `exp2@GLIBC_2.29'
... /0.8.0/osp/testing/package/3123ab7ca3fc5a20c4e01288f8e98c00a155d3bd/lib/libcosim.so: undefined reference to `log2@GLIBC_2.29'
```