### PR TITLE
Support relative FMU paths on Windows

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -8,24 +8,29 @@
 #include <cosim/fs_portability.hpp>
 
 #ifdef _WIN32
+#    include <algorithm>
 #    include <cctype>
 #endif
 
 
 cosim::uri to_uri(std::string_view str)
 {
-    auto uri = cosim::uri(str);
 #ifdef _WIN32
     // On Windows, we treate anything that starts with a single letter followed
     // by a colon as a path, even though it could also be interpreted as an URI
     // with a single-character scheme.
+    auto strWithSlashes = std::string(str);
+    std::replace(strWithSlashes.begin(), strWithSlashes.end(), '\\', '/');
+    auto uri = cosim::uri(strWithSlashes);
     const auto schemeLooksLikeDriveLetter =
         uri.scheme() &&
         uri.scheme()->size() == 1 &&
         std::isalpha(static_cast<unsigned char>(uri.scheme()->front()));
-    if (schemeLooksLikeDriveLetter || !uri.scheme()) {
+    if (schemeLooksLikeDriveLetter) {
         uri = cosim::path_to_file_uri(cosim::filesystem::path(str.begin(), str.end()));
     }
-#endif
     return uri;
+#else
+    return cosim::uri(str);
+#endif
 }


### PR DESCRIPTION
This fixes #84, enabling users to pass relative FMU paths to `inspect` and `run-single` on Windows too.  The problem was that we tried to call `cosim::path_to_file_uri()` even on relative paths, which doesn't make sense, since a relative path is *already* a relative URI reference. (On Windows we also have to replace backslashes with forward slashes for this to be true, which I've done here.)