### PR TITLE
Overriding zlib

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,6 @@
 [requires]
 libcosim/0.9.0@osp/stable
+zlib/1.2.12
 
 [generators]
 cmake


### PR DESCRIPTION
Resolves 
```
ERROR: Conflict in libzip/1.7.3:
    'libzip/1.7.3' requires 'zlib/1.2.11' while 'boost/1.71.0' requires 'zlib/1.2.12'.
    To fix this conflict you need to override the package 'zlib' in your root package.
```
