### PR TITLE
Cosim-cli 0 10 1 release

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        compiler_version: [8, 9]
+        compiler_version: [9]
         compiler_libcxx: [libstdc++11]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        compiler_version: [9]
+        compiler_version: [8, 9]
         compiler_libcxx: [libstdc++11]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
 endif()
 
 find_package(libcosim REQUIRED)
-find_package(Boost REQUIRED COMPONENTS program_options)
+find_package(Boost REQUIRED COMPONENTS program_options REQUIRED)
 
 # ==============================================================================
 # Targets
@@ -76,10 +76,7 @@ add_executable(cosim
     "src/version_option.cpp"
 )
 target_include_directories(cosim PRIVATE "${generatedFilesDir}")
-target_link_libraries(cosim
-    PRIVATE
-        libcosim::libcosim
-        Boost::program_options)
+target_link_libraries(cosim PRIVATE libcosim::libcosim Boost::program_options)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # This makes the linker set RPATH rather than RUNPATH for the resulting

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ set(CMAKE_VERBOSE_MAKEFILE OFF)
 # ==============================================================================
 # Global internal configuration
 # ==============================================================================
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
-list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
 # Use the highest warning levels and treat all warnings as errors,
 # but ignore a few selected warnings.
@@ -76,7 +74,7 @@ add_executable(cosim
     "src/version_option.cpp"
 )
 target_include_directories(cosim PRIVATE "${generatedFilesDir}")
-target_link_libraries(cosim PRIVATE libcosim::libcosim Boost::program_options)
+target_link_libraries(cosim PRIVATE libcosim::cosim Boost::program_options)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # This makes the linker set RPATH rather than RUNPATH for the resulting

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ set(CMAKE_VERBOSE_MAKEFILE OFF)
 # ==============================================================================
 # Global internal configuration
 # ==============================================================================
-list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
@@ -79,7 +78,7 @@ add_executable(cosim
 target_include_directories(cosim PRIVATE "${generatedFilesDir}")
 target_link_libraries(cosim
     PRIVATE
-        libcosim::libcosim
+        libcosim::cosim
         Boost::program_options)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
-project("cosim" VERSION "0.10.0")
+project("cosim" VERSION "0.8.0")
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/dist")
 
 # To enable verbose when needed
@@ -40,7 +40,7 @@ else()
 endif()
 
 find_package(libcosim REQUIRED)
-find_package(Boost REQUIRED COMPONENTS program_options REQUIRED)
+find_package(Boost REQUIRED COMPONENTS program_options)
 
 # ==============================================================================
 # Targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
-project("cosim" VERSION "0.8.0")
+project("cosim" VERSION "0.9.0")
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/dist")
 
 # To enable verbose when needed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
-project("cosim" VERSION "0.9.0")
+project("cosim" VERSION "0.10.0")
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/dist")
 
 # To enable verbose when needed
@@ -78,7 +78,7 @@ add_executable(cosim
 target_include_directories(cosim PRIVATE "${generatedFilesDir}")
 target_link_libraries(cosim
     PRIVATE
-        libcosim::cosim
+        libcosim::libcosim
         Boost::program_options)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ set(CMAKE_VERBOSE_MAKEFILE OFF)
 # ==============================================================================
 # Global internal configuration
 # ==============================================================================
+list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
 # Use the highest warning levels and treat all warnings as errors,
 # but ignore a few selected warnings.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ add_executable(cosim
 target_include_directories(cosim PRIVATE "${generatedFilesDir}")
 target_link_libraries(cosim
     PRIVATE
-        libcosim::cosim
+        libcosim::libcosim
         Boost::program_options)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,6 +3,7 @@ libcosim/0.10.0@osp/stable
 
 [generators]
 cmake
+cmake_find_package
 virtualrunenv
 
 [imports]

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-libcosim/0.10.0@osp/stable
+libcosim/0.10.1@osp/stable
 
 [generators]
 cmake

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-libcosim/0.10.0@osp/testing
+libcosim/0.10.0@osp/stable
 
 [generators]
 cmake

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,7 +3,6 @@ libcosim/0.10.1@osp/stable
 
 [generators]
 cmake
-cmake_find_package
 virtualrunenv
 
 [imports]

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -9,9 +9,9 @@
 #include <cosim/fs_portability.hpp>
 #include <cosim/log/logger.hpp>
 
+#include <cstdlib>
 #include <optional>
 #include <stdexcept>
-#include <cstdlib>
 
 namespace
 {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -9,10 +9,14 @@
 #include <cosim/fs_portability.hpp>
 #include <cosim/log/logger.hpp>
 
-#include <cstdlib>
 #include <optional>
 #include <stdexcept>
 
+
+namespace std
+{
+#include <cstdlib>
+};
 
 namespace
 {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -11,12 +11,7 @@
 
 #include <optional>
 #include <stdexcept>
-
-
-namespace std
-{
 #include <cstdlib>
-};
 
 namespace
 {


### PR DESCRIPTION
Preparing for v0.10.0 release of cli as well. 

@markaren @kyllingstad Thrift-related build error propagated here as well. Fixed by adding `CMAKE_MODULE_PATH` and `CMAKE_PREFIX_PATH` but there are still problems building & linking the executable. 

Notably, there's a lot of errors like `error C2039: 'optional': is not a member of 'std'`, and various other errors about C++17. Maybe stdc++ needs to be linked? 

I was able to build cosim.exe by adding `target_compile_features(cosim PRIVATE "cxx_std_17")`, but then the required DLLs like `boost::program_options` are not linked.