### PR TITLE
Libcosim update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/dist")
 # To enable verbose when needed
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
-# Suppress boost warnings for using version 1.81.0 (may not be needed for futuer release of cmake)
+# Suppress boost warnings for using version 1.81.0 (may not be needed for future release of cmake)
 set(Boost_NO_WARN_NEW_VERSIONS ON)
 
 # ==============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/dist")
 # To enable verbose when needed
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
+# Suppress boost warnings for using version 1.81.0 (may not be needed for futuer release of cmake)
+set(Boost_NO_WARN_NEW_VERSIONS ON)
+
 # ==============================================================================
 # Global internal configuration
 # ==============================================================================

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-libcosim/0.10.1@osp/stable
+libcosim/0.10.2@osp/stable
 
 [generators]
 cmake
@@ -20,9 +20,10 @@ bin, boost_thread*.dll             -> ./dist/bin
 bin, cosim.dll                     -> ./dist/bin
 bin, fmilib_shared.dll             -> ./dist/bin
 bin, xerces-c*.dll                 -> ./dist/bin
-bin, yaml-cpp.dll                  -> ./dist/bin
+bin, yaml-cpp*.dll                 -> ./dist/bin
 bin, zip.dll                       -> ./dist/bin
 bin, proxyfmu*                     -> ./dist/bin
+bin, fmilibwrapper*.dll            -> ./dist/bin
 
 lib, libboost_atomic.so.*          -> ./dist/lib
 lib, libboost_chrono.so.*          -> ./dist/lib
@@ -38,8 +39,10 @@ lib, libboost_thread.so.*          -> ./dist/lib
 lib, libcosim.so                   -> ./dist/lib
 lib, libfmilib_shared.so           -> ./dist/lib
 lib, libxerces-c*.so               -> ./dist/lib
-lib, libyaml-cpp.so.*              -> ./dist/lib
+lib, libyaml-cpp*.so.*             -> ./dist/lib
 lib, libzip.so.*                   -> ./dist/lib
+lib, libfmilibwrapper*.so          -> ./dist/lib
+lib, libproxyfmu-client*.so        -> ./dist/lib
 
 ., license*     -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
 ., */license*   -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False


### PR DESCRIPTION
Updated libcosim to 0.10.2

Because `proxyfmu-client` can now be built as a shared lib, copying the `dll` and `.so` files via `import` in `conanfile.txt`.