### PR TITLE
Compile with `shared=False` as default

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.files import copy
 
 class CosimCLIConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    default_options = { "*:shared": True }
+    default_options = { "*:shared": False }
 
     def requirements(self):
         self.tool_requires("cmake/[>=3.19]")


### PR DESCRIPTION
Fixes #102.

I recently ran into one of the issues described in #102, where both Cosim and the FMU depend on a the same shared library but in different, incompatible versions.