### PR TITLE
Update to v4 actions

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           name: cosim-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.compiler_version }}-${{ matrix.option_proxyfmu }}
           path: build/${{ matrix.build_type }}/dist
+          overwrite: true
 
   windows:
     name: Windows
@@ -81,3 +82,4 @@ jobs:
         with:
           name: cosim-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.option_proxyfmu }}
           path: build/dist
+          overwrite: true

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -45,7 +45,7 @@ jobs:
           mkdir -m 0777 build
           docker run --rm -v $(pwd):/mnt/source osp-builder
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cosim-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.compiler_version }}-${{ matrix.option_proxyfmu }}
           path: build/${{ matrix.build_type }}/dist
@@ -77,7 +77,7 @@ jobs:
           cmake --build build --config ${{ matrix.build_type }}
           cmake --build build --config ${{ matrix.build_type }} --target install
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cosim-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.option_proxyfmu }}
           path: build/dist

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,7 @@ class CosimCLIConan(ConanFile):
         self.tool_requires("cmake/[>=3.19]")
         if self.settings.os == "Linux":
             self.tool_requires("patchelf/[<0.18]")
-        self.requires("libcosim/0.10.3@osp/stable")
+        self.requires("libcosim/0.10.4@osp/stable")
         self.requires("boost/[>=1.71]")
 
     def layout(self):


### PR DESCRIPTION
Updated to v4 actions as I've received notice that artifact actions v3 will be sunset by the end of Jan 2025. Bump to latest release of libcosim while we're at it.

Some notes on the differences here:
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md