### PR TITLE
Modernise Linux CI workflow description a bit

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -6,46 +6,36 @@ on: [push, workflow_dispatch]
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        compiler_version: [9]
+        compiler_version: [14]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
+    runs-on: ubuntu-latest
+    container:
+      image: gcc:${{ matrix.compiler_version }}
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Generate Dockerfile
+      - uses: actions/checkout@v6
+      - name: Install prerequisites
         run: |
-          mkdir /tmp/osp-builder-docker
-          cat <<'EOF' >/tmp/osp-builder-docker/Dockerfile
-          FROM conanio/gcc${{ matrix.compiler_version }}-ubuntu16.04
-          COPY entrypoint.sh /
-          ENTRYPOINT /entrypoint.sh
-          EOF
-      - name: Generate entrypoint.sh
+          apt-get update
+          apt-get install -y pipx cmake doxygen
+          pipx install conan
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Configure Conan
         run: |
-          cat <<'EOF' >/tmp/osp-builder-docker/entrypoint.sh
-          #!/bin/bash -v
-          set -eu
-          conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
-          cd /mnt/source
+          conan profile detect
+          conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local
+      - name: Build
+        run: |
           conan install . -s build_type=${{ matrix.build_type }} -o "libcosim/*:${{ matrix.option_proxyfmu }}" --build=missing
           cmake -S . -B build/${{ matrix.build_type }} -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           cmake --build build/${{ matrix.build_type }}
           cmake --build build/${{ matrix.build_type }} --target install
-          EOF
-          chmod 0777 /tmp/osp-builder-docker/entrypoint.sh
-      - name: Build Docker image
-        run: docker build -t osp-builder /tmp/osp-builder-docker/
-      - name: Build cosim
-        run: |
-          chmod 0777 $(pwd) # because commands in conanio containers run as an unprivileged user
-          mkdir -m 0777 build
-          docker run --rm -v $(pwd):/mnt/source osp-builder
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cosim-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.compiler_version }}-${{ matrix.option_proxyfmu }}
           path: build/${{ matrix.build_type }}/dist
@@ -62,7 +52,7 @@ jobs:
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install prerequisites
         run: |
           pip3 install --upgrade setuptools pip
@@ -78,7 +68,7 @@ jobs:
           cmake --build build --config ${{ matrix.build_type }}
           cmake --build build --config ${{ matrix.build_type }} --target install
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cosim-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.option_proxyfmu }}
           path: build/dist


### PR DESCRIPTION
I've implemented the same change as in open-simulation-platform/libcosim#801, i.e., switching from building a custom container image to using a standard GCC image. I've also updated `actions/checkout` and `actions/upload-artifacts` to newer versions.